### PR TITLE
[IMP] Quotation Approval Logic

### DIFF
--- a/sale_quotation_approval/__manifest__.py
+++ b/sale_quotation_approval/__manifest__.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Quartile Limited
+# Copyright 2017-2018 Quartile Limited
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 {
     "name": "Quotation Approval",
     "summary": "",
-    "version": "10.0.1.1.0",
+    "version": "10.0.1.2.0",
     "category": "Sales",
-    "website": "https://www.odoo-asia.com/",
+    "website": "https://www.quartile.co/",
     "author": "Quartile Limited",
     "license": "LGPL-3",
     "application": False,

--- a/sale_quotation_approval/i18n/ja.po
+++ b/sale_quotation_approval/i18n/ja.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-06-13 11:11+0000\n"
-"PO-Revision-Date: 2017-06-13 11:11+0000\n"
+"POT-Creation-Date: 2018-05-24 09:18+0000\n"
+"PO-Revision-Date: 2018-05-24 09:18+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -16,9 +16,36 @@ msgstr ""
 "Plural-Forms: \n"
 
 #. module: sale_quotation_approval
+#: model:ir.ui.view,arch_db:sale_quotation_approval.external_layout_nrq
+msgid "<span>Draft Quotation</span>"
+msgstr "<span>ドラフト見積書</span>"
+
+#. module: sale_quotation_approval
+#: model:ir.ui.view,arch_db:sale_quotation_approval.external_layout_nrq
+msgid "<span>Quotation</span>"
+msgstr "<span>見積書</span>"
+
+#. module: sale_quotation_approval
+#: model:ir.model.fields,field_description:sale_quotation_approval.field_sale_order_approval_availability
+msgid "Approval Availability"
+msgstr "承認可能"
+
+#. module: sale_quotation_approval
 #: model:ir.ui.view,arch_db:sale_quotation_approval.view_order_form
 msgid "Approve"
 msgstr "承認"
+
+#. module: sale_quotation_approval
+#: model:ir.model.fields,field_description:sale_quotation_approval.field_sale_order_approval
+#: model:ir.ui.view,arch_db:sale_quotation_approval.sale_order_view_search_inherit_quotation
+#: model:ir.ui.view,arch_db:sale_quotation_approval.view_order_form
+msgid "Approved"
+msgstr "承認済"
+
+#. module: sale_quotation_approval
+#: model:ir.model.fields,field_description:sale_quotation_approval.field_sale_order_approval_user_id
+msgid "Approver"
+msgstr "承認者"
 
 #. module: sale_quotation_approval
 #: model:ir.ui.view,arch_db:sale_quotation_approval.view_order_form
@@ -36,18 +63,8 @@ msgid "Sales Order"
 msgstr "受注"
 
 #. module: sale_quotation_approval
-#: model:ir.model.fields,field_description:sale_quotation_approval.field_sale_order_approval
-#: model:ir.ui.view,arch_db:sale_quotation_approval.sale_order_view_search_inherit_quotation
-msgid "Approved"
-msgstr "承認済"
+#: model:ir.model.fields,field_description:sale_quotation_approval.field_sale_order_self_approval_permission
+msgid "Self-approval Permission"
+msgstr "自己承認許可"
 
-#. module: sale_quotation_approval
-#: model:ir.ui.view,arch_db:sale_quotation_approval.external_layout_nrq
-msgid "<span>Quotation</span>"
-msgstr "<span>見積書</span>"
-
-#. module: sale_quotation_approval
-#: model:ir.ui.view,arch_db:sale_quotation_approval.external_layout_nrq
-msgid "<span>Draft Quotation</span>"
-msgstr "<span>ドラフト見積書</span>"
 

--- a/sale_quotation_approval/models/sale_order.py
+++ b/sale_quotation_approval/models/sale_order.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Quartile Limited
+# Copyright 2017-2018 Quartile Limited
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
 
 from odoo import api, fields, models
@@ -14,6 +14,19 @@ class SaleOrder(models.Model):
         default=False,
         copy=False,
         track_visibility='onchange',
+    )
+    approval_user_id = fields.Many2one(
+        'res.users',
+        string='Approver',
+        readonly=True,
+    )
+    self_approval_permission = fields.Boolean(
+        string='Self-approval Permission',
+        default=False,
+    )
+    approval_availability = fields.Boolean(
+        string='Approval Availability',
+        compute='_compute_approval_availability',
     )
 
     @api.multi
@@ -33,8 +46,16 @@ class SaleOrder(models.Model):
     def action_approve(self):
         for quote in self:
             quote.approval = True
+            quote.approval_user_id = quote.env.user.id
 
     @api.multi
     def action_cancel_approval(self):
         for quote in self:
             quote.approval = False
+            quote.approval_user_id = False
+
+    @api.multi
+    def _compute_approval_availability(self):
+        for quote in self:
+            quote.approval_availability = (quote.user_id != quote.env.user) \
+                                          or quote.self_approval_permission

--- a/sale_quotation_approval/views/sale_order_views.xml
+++ b/sale_quotation_approval/views/sale_order_views.xml
@@ -8,18 +8,29 @@
             <xpath expr="//button[@name='action_confirm' and @states='draft']" position="replace"/>
             <xpath expr="//button[@name='action_confirm' and @states='sent']" position="replace"/>
             <xpath expr="//button[@name='print_quotation']" position="after">
-                <button name="action_approve" type="object" attrs="{'invisible':['|',('approval','=',True), ('state', 'in', ['sale', 'cancel', 'done'])]}" string="Approve" class="oe_highlight" groups="sales_team.group_sale_manager"/>
+                <button name="action_approve" type="object"
+                        attrs="{'invisible':['|', '|', ('approval','=',True), ('state', 'in', ['sale', 'cancel', 'done']), ('approval_availability', '=', False)]}" string="Approve" class="oe_highlight" groups="sales_team.group_sale_manager"/>
                 <button name="action_confirm" attrs="{'invisible': ['|', ('approval','=', False), ('state', '!=', 'sent')]}" string="Confirm Sale" class="btn-primary o_sale_confirm" type="object"/>
                 <button name="action_confirm" attrs="{'invisible': ['|', ('approval','=', False), ('state', '!=', 'draft')]}" string="Confirm Sale" class="o_sale_confirm" type="object"/>
                 <button name="action_cancel_approval" type="object" attrs="{'invisible':['|',('approval','=',False), ('state', 'in', ['sale', 'cancel', 'done'])]}" string="Cancel Approval" groups="sales_team.group_sale_manager"/>
             </xpath>
             <xpath expr="//field[@name='date_order']" position="before">
-                <field name="approval" states="draft,sent"/>
+                <label for="approval" string="Approved"/>
+                <div>
+                    <field name="approval" states="draft,sent"/>
+                    <field name="approval_user_id"/>
+                    <field name="approval_availability" invisible="True"/>
+                </div>
             </xpath>
             <xpath expr="//field[@name='order_line']" position="attributes">
                 <attribute name="attrs">{'readonly':['|', ('approval', '=', True), ('state', 'in', ('done','cancel'))]}</attribute>
             </xpath>
-
+            <xpath expr="//field[@name='related_project_id']"
+                   position="after">
+                <field name="self_approval_permission"
+                       groups="sales_team.group_sale_manager"
+                       attrs="{'readonly':[('approval', '=', True)]}"/>
+            </xpath>
         </field>
     </record>
 
@@ -33,6 +44,7 @@
             </xpath>
             <xpath expr="//field[@name='state']" position="after">
                 <field name="approval"/>
+                <field name="approval_user_id"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
@yostashiro, here is the PR for the `sale_quotation_approval` improvements.
1. Add a new field to judge whether the user is able to approve the quotation, i.e. `approval_availability`
2. User who approves the sales order will be recorded as `approver` of the quotation, the field will be cleared if the sales order is being disapproved.
3. The "Approve" button will only be displayed when:
    i) The user is a sales manager
    ii) The current user is not the salesperson or the `self_approval_permission` is `True`