### PR TITLE
[FIX] Make pj_id a stored field

### DIFF
--- a/account_analytic_profit_loss_analysis/__manifest__.py
+++ b/account_analytic_profit_loss_analysis/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Analytic Account Profit and Loss Analysis",
     "summary": "",
     "description": """""",
-    "version": "10.0.1.1.2",
+    "version": "10.0.1.2.0",
     "category": "Accounting",
     "website": "https://www.quartile.co/",
     "author": "Quartile Limited",

--- a/account_analytic_profit_loss_analysis/models/account_analytic_line.py
+++ b/account_analytic_profit_loss_analysis/models/account_analytic_line.py
@@ -24,6 +24,7 @@ class AccountAnalyticLine(models.Model):
         string='Related Project',
         compute='_compute_pj_id',
         inverse='_set_account_id',
+        store=True,
     )
     parent_project_id = fields.Many2one(
         related='pj_id.parent_project_id',


### PR DESCRIPTION
@yostashiro When creating a project, all the `pj_id` tries to re-compute which causes a long loading.
By setting it to `store`, the compute method will only run with the `account_id` is updated. 