### PR TITLE
[FIX] computation and search of sheet_id

### DIFF
--- a/hr_attendance_timesheet_adj/__manifest__.py
+++ b/hr_attendance_timesheet_adj/__manifest__.py
@@ -6,7 +6,7 @@
     'summary': '',
     'description': '''
     ''',
-    'version': '10.0.1.0.0',
+    'version': '10.0.1.1.0',
     'category': 'HR',
     'website': 'https://www.quartile.co/',
     'author': 'Quartile Limited',

--- a/hr_attendance_timesheet_adj/models/hr_attendance.py
+++ b/hr_attendance_timesheet_adj/models/hr_attendance.py
@@ -2,7 +2,12 @@
 # Copyright 2018 Quartile Limited
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import models, fields, api
+from datetime import datetime
+from pytz import timezone
+import pytz
+
+from odoo import api, fields, models
+from odoo.tools import DEFAULT_SERVER_DATE_FORMAT, DEFAULT_SERVER_DATETIME_FORMAT
 
 
 class HrAttendance(models.Model):
@@ -20,3 +25,47 @@ class HrAttendance(models.Model):
     @api.onchange('employee_id', 'check_in', 'check_out')
     def _onchange_update_manually(self):
         self.update_manually = True
+
+    @api.depends('employee_id', 'check_in', 'check_out',
+                 'sheet_id_computed.date_to',
+                 'sheet_id_computed.date_from',
+                 'sheet_id_computed.employee_id')
+    def _compute_sheet(self):
+        """Links the attendance to the corresponding sheet
+        """
+        for attendance in self:
+            att_tz_date_str = attendance._get_attendance_employee_tz(
+                attendance.employee_id.id, attendance.check_in)
+            corresponding_sheet = self.env[
+                'hr_timesheet_sheet.sheet'].search(
+                [('date_to', '>=', att_tz_date_str),
+                 ('date_from', '<=', att_tz_date_str),
+                 ('employee_id', '=', attendance.employee_id.id),
+                 ('state', 'in', ['draft', 'new'])], limit=1)
+            if corresponding_sheet:
+                attendance.sheet_id_computed = corresponding_sheet[0]
+                attendance.sheet_id = corresponding_sheet[0]
+
+    def _search_sheet(self, operator, value):
+        assert operator == 'in'
+        ids = []
+        for ts in self.env['hr_timesheet_sheet.sheet'].browse(value):
+            local_tz = timezone(
+                ts.employee_id.user_id.partner_id.tz or 'utc')
+            local_date_from_dt = local_tz.localize(datetime.strptime(
+                ts.date_from, DEFAULT_SERVER_DATE_FORMAT))
+            local_date_to_dt = local_tz.localize(datetime.strptime(
+                ts.date_to, DEFAULT_SERVER_DATE_FORMAT))
+            utc_date_from_dt = local_date_from_dt.astimezone(pytz.utc)
+            utc_date_to_dt = local_date_to_dt.astimezone(pytz.utc)
+            self._cr.execute("""
+                    SELECT a.id
+                        FROM hr_attendance a
+                    WHERE %(date_to)s >= a.check_in
+                        AND %(date_from)s <= a.check_in
+                        AND %(employee_id)s = a.employee_id
+                    GROUP BY a.id""", {'date_from': utc_date_from_dt,
+                                       'date_to': utc_date_to_dt,
+                                       'employee_id': ts.employee_id.id, })
+            ids.extend([row[0] for row in self._cr.fetchall()])
+        return [('id', 'in', ids)]


### PR DESCRIPTION
- The `Sheet` of the attendance record will be incorrect for the records that `check_in` (local time) is equal to or after the `date_from` of the timesheet but `check_in` (UTC time) is before `date_from` of the timesheet
- For some countries like Japan that timezone difference is larger than 9 hours, e.g. >GMT+9, the record on the first day of the month will always be abandoned, i.e. empty `Sheet` field even the timesheets are no-gap and there will not be any user error when the attendance is created.