### PR TITLE
[FIX] Pass string instead of datetime object to the sql

### DIFF
--- a/hr_attendance_timesheet_adj/models/hr_attendance.py
+++ b/hr_attendance_timesheet_adj/models/hr_attendance.py
@@ -56,8 +56,10 @@ class HrAttendance(models.Model):
                 ts.date_from, DEFAULT_SERVER_DATE_FORMAT))
             local_date_to_dt = local_tz.localize(datetime.strptime(
                 ts.date_to, DEFAULT_SERVER_DATE_FORMAT))
-            utc_date_from_dt = local_date_from_dt.astimezone(pytz.utc)
-            utc_date_to_dt = local_date_to_dt.astimezone(pytz.utc)
+            utc_date_from_dt = local_date_from_dt.astimezone(
+                pytz.utc).strftime('%Y-%m-%d %H:%M:%S')
+            utc_date_to_dt = local_date_to_dt.astimezone(pytz.utc).strftime(
+                '%Y-%m-%d %H:%M:%S')
             self._cr.execute("""
                     SELECT a.id
                         FROM hr_attendance a


### PR DESCRIPTION
- When passing the `datetime` object to the SQL, some environment will convert it to UTC time string while some of them will convert back to a local time string. Therefore a string need to be passed to the SQL.