### PR TITLE
[IMP] Patch the copyfileobj method to increase the buffer size

### DIFF
--- a/auto_backup/__init__.py
+++ b/auto_backup/__init__.py
@@ -5,3 +5,4 @@
 # License GPL-3.0 or later (http://www.gnu.org/licenses/gpl.html).
 
 from . import models
+from . import shutil

--- a/auto_backup/shutil.py
+++ b/auto_backup/shutil.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+# Copyright 2018 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/gpl.html).
+
+import shutil
+
+
+def _copyfileobj_patched(fsrc, fdst, length=16*1024*1024):
+    """Patches shutil method to increase the buffer size"""
+    while 1:
+        buf = fsrc.read(length)
+        if not buf:
+            break
+        fdst.write(buf)
+
+shutil.copyfileobj = _copyfileobj_patched


### PR DESCRIPTION
Since the transfer speed of the backup file is too slow, here we try to introduce the patch from https://stackoverflow.com/a/28584857 to increase the buffer size. 