### PR TITLE
[FIX] Adjust timesheet end date range

### DIFF
--- a/hr_attendance_timesheet_adj/__manifest__.py
+++ b/hr_attendance_timesheet_adj/__manifest__.py
@@ -6,7 +6,7 @@
     'summary': '',
     'description': '''
     ''',
-    'version': '10.0.1.1.0',
+    'version': '10.0.1.2.0',
     'category': 'HR',
     'website': 'https://www.quartile.co/',
     'author': 'Quartile Limited',

--- a/hr_attendance_timesheet_adj/models/hr_attendance.py
+++ b/hr_attendance_timesheet_adj/models/hr_attendance.py
@@ -53,9 +53,11 @@ class HrAttendance(models.Model):
             local_tz = timezone(
                 ts.employee_id.user_id.partner_id.tz or 'utc')
             local_date_from_dt = local_tz.localize(datetime.strptime(
-                ts.date_from, DEFAULT_SERVER_DATE_FORMAT))
+                ts.date_from, DEFAULT_SERVER_DATE_FORMAT)).replace(
+                    hour=0, minute=0, second=0)
             local_date_to_dt = local_tz.localize(datetime.strptime(
-                ts.date_to, DEFAULT_SERVER_DATE_FORMAT))
+                ts.date_to, DEFAULT_SERVER_DATE_FORMAT)).replace(
+                    hour=23, minute=59, second=59)
             utc_date_from_dt = local_date_from_dt.astimezone(
                 pytz.utc).strftime('%Y-%m-%d %H:%M:%S')
             utc_date_to_dt = local_date_to_dt.astimezone(pytz.utc).strftime(


### PR DESCRIPTION
- When the end date is passed to the `_search_sheet()`, it should convert to a `Datetime` object that covers the whole day, i.e. `2018-11-30` should convert to `2018-11-30 23:59:59` instead of `2018-11-30 00:00:00`

Logic Flow:
1. User enter the Start Date and End Date of the timesheet. 
2. Both date are converted to `Datetime` objects.
3. When the user is not in UTC timezone, since the records in the database are in UTC, therefore we need to convert the `datetime` object to UTC.
4. Use the converted value to perform the search in the database and grep the attendance records within the date range.
