### PR TITLE
[IMP] add 'draft' state to expense report

### DIFF
--- a/hr_expense_adj/__manifest__.py
+++ b/hr_expense_adj/__manifest__.py
@@ -1,29 +1,20 @@
 # -*- coding: utf-8 -*-
 # Copyright 2017-2018 Quartile Limited
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Adjustments on Expense Functions",
     "summary": "",
     "description": """
-* Hide "Submit to Manager" button and Account field in expense form
-* Adjust expense tree view fields
-* Propose a default value in expense report summary field
+* Hides "Submit to Manager" button and Account field in expense form
+* Proposes default values in expense report summary field
+* Adds 'draft' state to expense report
     """,
-    "version": "10.0.1.3.1",
+    "version": "10.0.1.4.0",
     "category": "HR",
     "website": "https://www.quartile.co/",
     "author": "Quartile Limited",
-    "license": "LGPL-3",
-    "application": False,
+    "license": "AGPL-3",
     "installable": True,
-    "pre_init_hook": "",
-    "post_init_hook": "",
-    "post_load": "",
-    "uninstall_hook": "",
-    "external_dependencies": {
-        "python": [],
-        "bin": [],
-    },
     "depends": [
         "hr_expense",
         "ir_sequence_range_month",
@@ -33,8 +24,4 @@
         'views/hr_expense_views.xml',
         'views/hr_expense_sheet_views.xml',
     ],
-    "demo": [
-    ],
-    "qweb": [
-    ]
 }

--- a/hr_expense_adj/i18n/ja.po
+++ b/hr_expense_adj/i18n/ja.po
@@ -6,14 +6,29 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 10.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-05-17 08:37+0000\n"
-"PO-Revision-Date: 2017-05-17 08:37+0000\n"
+"POT-Creation-Date: 2018-11-27 09:30+0000\n"
+"PO-Revision-Date: 2018-11-27 09:30+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: \n"
 "Plural-Forms: \n"
+
+#. module: hr_expense_adj
+#: model:ir.ui.view,arch_db:hr_expense_adj.view_hr_expense_sheet_form
+msgid "Cancel Submission"
+msgstr "申請取消"
+
+#. module: hr_expense_adj
+#: model:ir.ui.view,arch_db:hr_expense_adj.hr_expense_form_view_adj
+msgid "Documents"
+msgstr "ドキュメント"
+
+#. module: hr_expense_adj
+#: model:ir.ui.view,arch_db:hr_expense_adj.view_hr_expense_sheet_filter
+msgid "Draft Expenses"
+msgstr "ドラフト経費"
 
 #. module: hr_expense_adj
 #: model:ir.model,name:hr_expense_adj.model_hr_expense
@@ -38,6 +53,11 @@ msgid "Expense Type"
 msgstr "経費種別"
 
 #. module: hr_expense_adj
+#: model:ir.ui.view,arch_db:hr_expense_adj.hr_expense_form_view_adj
+msgid "Expenses"
+msgstr "経費"
+
+#. module: hr_expense_adj
 #: model:ir.model.fields,field_description:hr_expense_adj.field_hr_expense_number
 msgid "Number"
 msgstr "経費番号"
@@ -46,11 +66,6 @@ msgstr "経費番号"
 #: model:ir.ui.view,arch_db:hr_expense_adj.hr_expense_form_view_adj
 msgid "Please mention here any special situation to note.  e.g. there is no expense for this month, receipt has been lost, etc."
 msgstr "当月に経費が発生しない場合、領収書を紛失した場合などはこちらにその旨入力してください。"
-
-#. module: hr_expense_adj
-#: model:ir.ui.view,arch_db:hr_expense_adj.hr_expense_form_view
-msgid "Preserved Text"
-msgstr "Preserved Text"
 
 #. module: hr_expense_adj
 #: model:ir.ui.view,arch_db:hr_expense_adj.hr_expense_form_view_adj
@@ -66,13 +81,33 @@ msgstr "←の「経費内訳等」にマウスを置くと、書き方の説明
 
 #. module: hr_expense_adj
 #: model:ir.ui.view,arch_db:hr_expense_adj.view_hr_expense_sheet_form
+msgid "Set to Draft"
+msgstr "ドラフトに設定"
+
+#. module: hr_expense_adj
+#: model:ir.ui.view,arch_db:hr_expense_adj.view_hr_expense_sheet_form
 msgid "Submit"
 msgstr "申請"
 
 #. module: hr_expense_adj
-#: model:ir.model,name:hr_expense_adj.model_ir_sequence
-msgid "ir.sequence"
-msgstr "ir.sequence"
+#: model:ir.ui.view,arch_db:hr_expense_adj.hr_expense_form_view_adj
+msgid "Submit to Manager"
+msgstr "マネジャに申請"
+
+#. module: hr_expense_adj
+#: model:ir.ui.view,arch_db:hr_expense_adj.view_hr_expense_sheet_filter
+msgid "To Submit"
+msgstr "未申請"
+
+#. module: hr_expense_adj
+#: model:ir.ui.view,arch_db:hr_expense_adj.hr_expense_form_view_adj
+msgid "View Report"
+msgstr "レポートを表示"
+
+#. module: hr_expense_adj
+#: selection:hr.expense.sheet,state:0
+msgid "Draft"
+msgstr "ドラフト"
 
 #. module: hr_expense
 #: model:ir.model.fields,help:hr_expense.field_hr_expense_name
@@ -118,39 +153,6 @@ msgstr "稟議番号とは『決裁番号』のことで『文書番号』では
 "物品購入、接待、出張等は稟議番号を入力してください。"
 
 #. module: hr_expense
-#: model:ir.model.fields,field_description:hr_expense.field_hr_expense_name
-msgid "Expense Description"
-msgstr "経費内訳等"
-
-#. module: hr_expense
-#: model:ir.model.fields,field_description:hr_expense.field_hr_expense_product_id
-#: model:ir.ui.view,arch_db:hr_expense.view_hr_expense_filter
-msgid "Product"
-msgstr "経費種別"
-
-#. module: hr_expense_adj
-#: model:ir.model.fields,field_description:hr_expense_adj.field_hr_expense_sheet_submitted
-msgid "Submitted"
-msgstr "申請済"
-
-#. module: hr_expense_adj
-#: model:ir.ui.view,arch_db:hr_expense_adj.view_hr_expense_sheet_form
-msgid "Cancel Submission"
-msgstr "申請取消"
-
-#. modules: hr_expense, hr_expense_adj
-#: model:ir.ui.view,arch_db:hr_expense.view_hr_expense_sheet_form
-#: model:ir.ui.view,arch_db:hr_expense_adj.view_hr_expense_sheet_form
-msgid "Approve"
-msgstr "承認"
-
-#. module: hr_expense
 #: model:ir.model.fields,field_description:hr_expense.field_hr_expense_reference
 msgid "Bill Reference"
 msgstr "稟議番号"
-
-#. module: hr_expense
-#: selection:hr.expense.sheet,state:0
-#: model:mail.message.subtype,name:hr_expense.mt_expense_confirmed
-msgid "To Be Approved"
-msgstr "未承認"

--- a/hr_expense_adj/models/hr_expense.py
+++ b/hr_expense_adj/models/hr_expense.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
-# Copyright 2017 Quartile Limited
-# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl).
+# Copyright 2017-2018 Quartile Limited
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
 from odoo import models, fields, api
 

--- a/hr_expense_adj/views/hr_expense_sheet_views.xml
+++ b/hr_expense_adj/views/hr_expense_sheet_views.xml
@@ -1,29 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
 
-    <record id="view_hr_expense_sheet_tree" model="ir.ui.view">
-        <field name="name">hr.expense.sheet.tree</field>
-        <field name="model">hr.expense.sheet</field>
-        <field name="inherit_id" ref="hr_expense.view_hr_expense_sheet_tree"/>
-        <field name="arch" type="xml">
-            <xpath expr="//field[@name='state']" position="after">
-                <field name="submitted"/>
-            </xpath>
-        </field>
-    </record>
-
     <record id="view_hr_expense_sheet_form" model="ir.ui.view">
         <field name="name">hr.expense.sheet.form</field>
         <field name="model">hr.expense.sheet</field>
         <field name="inherit_id" ref="hr_expense.view_hr_expense_sheet_form"/>
         <field name="arch" type="xml">
-            <xpath expr="//button[@name='approve_expense_sheets']" position="replace">
-                <button name="action_submit" type="object" attrs="{'invisible':['|',('submitted','=',True), ('state','!=','submit')]}" string="Submit" class="oe_highlight"/>
-                <button name="action_cancel_submission" type="object" attrs="{'invisible':['|',('submitted','=',False), ('state','!=','submit')]}" string="Cancel Submission"/>
-                <button name="approve_expense_sheets" attrs="{'invisible':['|',('submitted','=',False), ('state','!=','submit')]}" string="Approve" type="object" groups="hr_expense.group_hr_expense_user" class="oe_highlight o_expense_sheet_approve"/>
+            <xpath expr="//field[@name='state']" position="attributes">
+                <attribute name="statusbar_visible">draft,submit,approve,post,done</attribute>
             </xpath>
-            <xpath expr="//button[@name='%(hr_expense.hr_expense_refuse_wizard_action)d'][1]" position="replace">
-                <button name="%(hr_expense.hr_expense_refuse_wizard_action)d" attrs="{'invisible':['|',('submitted','=',False), ('state','!=','submit')]}" string="Refuse" type="action" groups="hr_expense.group_hr_expense_user" />
+            <xpath expr="//button[@name='approve_expense_sheets']" position="before">
+                <button name="action_submit" type="object" states="draft" string="Submit" class="oe_highlight"/>
+                <button name="action_cancel_submission" type="object" states="submit" string="Cancel Submission"/>
+            </xpath>
+            <xpath expr="//button[@name='reset_expense_sheets']" position="attributes">
+                <attribute name="string">Set to Draft</attribute>
             </xpath>
             <xpath expr="//tree" position="attributes">
                 <attribute name="default_order">date,id</attribute>
@@ -43,8 +34,16 @@
             <xpath expr="//tree/field[@name='total_amount']" position="after">
                 <field name="description"/>
             </xpath>
-            <xpath expr="//field[@name='journal_id']" position="before">
-                <field name="submitted"/>
+        </field>
+    </record>
+
+    <record id="view_hr_expense_sheet_filter" model="ir.ui.view">
+        <field name="name">hr.expense.sheet.filter</field>
+        <field name="model">hr.expense.sheet</field>
+        <field name="inherit_id" ref="hr_expense.view_hr_expense_sheet_filter"/>
+        <field name="arch" type="xml">
+            <xpath expr="filter[@name='submitted']" position="before">
+                <filter domain="[('state', '=', 'draft')]" string="To Submit" name="draft" help="Draft Expenses"/>
             </xpath>
         </field>
     </record>

--- a/hr_expense_adj/views/hr_expense_views.xml
+++ b/hr_expense_adj/views/hr_expense_views.xml
@@ -84,7 +84,6 @@
                     <field name="company_id" groups="base.group_multi_company"/>
                     <div>
                         <field name="description" placeholder="Please mention here any special situation to note.  e.g. there is no expense for this month, receipt has been lost, etc."/>
-                        <p>Preserved Text</p>
                     </div>
                 </sheet>
                 <div class="oe_chatter">


### PR DESCRIPTION
This update intends to allow users to review and modify expense report content before submitting it to the manager by inserting 'draft' state before 'submit'.