### PR TITLE
[FIX] allow adding expense items to draft report

### DIFF
--- a/hr_expense_adj/__manifest__.py
+++ b/hr_expense_adj/__manifest__.py
@@ -9,7 +9,7 @@
 * Proposes default values in expense report summary field
 * Adds 'draft' state to expense report
     """,
-    "version": "10.0.1.4.0",
+    "version": "10.0.1.4.1",
     "category": "HR",
     "website": "https://www.quartile.co/",
     "author": "Quartile Limited",

--- a/hr_expense_adj/i18n/ja.po
+++ b/hr_expense_adj/i18n/ja.po
@@ -44,7 +44,7 @@ msgstr "経費内訳等"
 #. module: hr_expense_adj
 #: model:ir.model,name:hr_expense_adj.model_hr_expense_sheet
 msgid "Expense Report"
-msgstr "経費レポート"
+msgstr "経費報告"
 
 #. module: hr_expense_adj
 #: model:ir.ui.view,arch_db:hr_expense_adj.hr_expense_form_view_adj
@@ -102,7 +102,7 @@ msgstr "未申請"
 #. module: hr_expense_adj
 #: model:ir.ui.view,arch_db:hr_expense_adj.hr_expense_form_view_adj
 msgid "View Report"
-msgstr "レポートを表示"
+msgstr "報告を表示"
 
 #. module: hr_expense_adj
 #: selection:hr.expense.sheet,state:0

--- a/hr_expense_adj/models/hr_expense_sheet.py
+++ b/hr_expense_adj/models/hr_expense_sheet.py
@@ -66,12 +66,12 @@ class HrExpenseSheet(models.Model):
     @api.multi
     def write(self, vals):
         res = super(HrExpenseSheet, self).write(vals)
-        if self.state == 'submit':
+        if self.state in ['draft', 'submit']:
             for line in self.expense_line_ids.sorted(
                     key=lambda x: (x.date, x.id)):
                 if line.number == False:
                     self._assign_number(line)
-            return res
+        return res
 
     @api.multi
     def unlink(self):


### PR DESCRIPTION
This fixes the issue of users not being able to add expense items to expense report when the report is in draft state.