### PR TITLE
[IMP] Fix button box, HR Settings Tab

### DIFF
--- a/hr_employee_nrq/__manifest__.py
+++ b/hr_employee_nrq/__manifest__.py
@@ -15,6 +15,7 @@
         "hr",
         "hr_contract",
         "hr_holidays",
+        "hr_timesheet_sheet",
     ],
     "data": [
         'views/hr_employee_views.xml',

--- a/hr_employee_nrq/models/hr_employee.py
+++ b/hr_employee_nrq/models/hr_employee.py
@@ -18,6 +18,10 @@ class HrEmployee(models.Model):
     year_enrolled = fields.Char(
         compute='_get_year_enrolled'
     )
+    employee_info_visible = fields.Boolean(
+        compute='_compute_employee_info_visible',
+        string='Employee Information Visibility',
+    )
 
     @api.multi
     def _get_year_enrolled(self):
@@ -31,3 +35,10 @@ class HrEmployee(models.Model):
                 employee.year_enrolled = _("%s Year %s Month(s)") % (
                     difference.years or '0', difference.months or '0'
                 )
+
+    @api.multi
+    def _compute_employee_info_visible(self):
+        for employee in self:
+            employee.employee_info_visible = True \
+                if employee.user_id == self.env.user or \
+                   self.env.user.has_group('hr.group_hr_user') else False

--- a/hr_employee_nrq/views/hr_employee_views.xml
+++ b/hr_employee_nrq/views/hr_employee_views.xml
@@ -33,6 +33,19 @@
             <xpath expr="//field[@name='calendar_id']" position="attributes">
                 <attribute name="invisible">1</attribute>
             </xpath>
+            <xpath expr="//div[@name='button_box']" position="inside">
+                <field name="employee_info_visible" invisible="1"/>
+            </xpath>
+            <xpath expr="//div[@name='button_box']" position="attributes">
+                <attribute name="groups"/>
+            </xpath>
+            <xpath expr="//button[@name='toggle_active']" position="attributes">
+                <attribute name="groups">hr.group_hr_user</attribute>
+            </xpath>
+            <xpath expr="//page[@groups='hr.group_hr_user'][2]" position="attributes">
+                <attribute name="groups"/>
+                <attribute name="attrs">{'invisible':[('employee_info_visible', '!=', True)]}</attribute>
+            </xpath>
         </field>
     </record>
 
@@ -46,6 +59,18 @@
             </xpath>
             <xpath expr="//page[3]//group[2]" position="attributes">
                 <attribute name="invisible">1</attribute>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="hr_timesheet_sheet_employee_extd_form" model="ir.ui.view">
+        <field name="name">hr.employee.form</field>
+        <field name="model">hr.employee</field>
+        <field name="inherit_id" ref="hr_timesheet_sheet.hr_timesheet_sheet_employee_extd_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//button[@groups='hr_timesheet.group_hr_timesheet_user']" position="attributes">
+                <attribute name="groups"/>
+                <attribute name="attrs">{'invisible':[('employee_info_visible', '!=', True)]}</attribute>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
- For employee, the user should be able to see his/her own "HR Settings" tab, and also the "Timesheet" button in the form view. Therefore this PR adds `employee_info_visible` to `hr.employee`, display the buttons according to the group settings / accessing employee record.
