### PR TITLE
[FIX] Adjust permission of Qualifications and Dependants

### DIFF
--- a/l10n_jp_hr_employee/security/hr_security.xml
+++ b/l10n_jp_hr_employee/security/hr_security.xml
@@ -16,7 +16,7 @@
     <record id="hr_qualification_user_rule" model="ir.rule">
         <field name="name">My Qualifications</field>
         <field ref="model_hr_qualification" name="model_id"/>
-        <field name="domain_force">[('employee_id.user_id','=',user.id)]</field>
+        <field name="domain_force">['|', ('employee_id.user_id','=',user.id), ('employee_id','=',False)]</field>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
     </record>
     <record id="hr_qualification_manager_rule" model="ir.rule">
@@ -28,7 +28,7 @@
     <record id="hr_dependant_user_rule" model="ir.rule">
         <field name="name">My Dependants</field>
         <field ref="model_hr_dependant" name="model_id"/>
-        <field name="domain_force">[('employee_id.user_id','=',user.id)]</field>
+        <field name="domain_force">['|', ('employee_id.user_id','=',user.id), ('employee_id','=',False)]</field>
         <field name="groups" eval="[(4, ref('base.group_user'))]"/>
     </record>
     <record id="hr_dependant_manager_rule" model="ir.rule">


### PR DESCRIPTION
Since `employee_id` is `False` for the new Qualifications and Dependants records, adding the condition to the existing record rule otherwise the validation error's message will not be shown.