### PR TITLE
[1062][IMP] Add gross_profit_margin_input as required field

### DIFF
--- a/sale_order_adj/__manifest__.py
+++ b/sale_order_adj/__manifest__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018 Quartile Limited
+# Copyright 2018-2020 Quartile Limited
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 {
     "name": "Adjustments on Sales Functions",
@@ -9,7 +9,7 @@
 - Show Untaxed Amount in the list view
 - Show Confirmation Date instead of order date in the list view
     """,
-    "version": "10.0.1.1.0",
+    "version": "10.0.1.2.0",
     "category": "Sales",
     "website": "https://www.quartile.co/",
     "author": "Quartile Limited",

--- a/sale_order_adj/i18n/ja.po
+++ b/sale_order_adj/i18n/ja.po
@@ -17,6 +17,7 @@ msgstr ""
 
 #. module: sale_order_adj
 #: model:ir.model.fields,field_description:sale_order_adj.field_sale_order_gross_profit_margin
+#: model:ir.model.fields,field_description:sale_order_adj.field_sale_order_gross_profit_margin_input
 msgid "Gross Profit Margin"
 msgstr "粗利率（予定）"
 
@@ -29,3 +30,10 @@ msgstr "プロジェクトマネジャ"
 #: model:ir.model,name:sale_order_adj.model_sale_order
 msgid "Sales Order"
 msgstr "受注"
+
+#. module: sale_order_adj
+#: code:addons/sale_order_adj/models/sale_order.py:30
+#, python-format
+msgid "The gross_profit_margin must be a number."
+msgstr "粗利率（予定）には数値のみで入力してください。"
+

--- a/sale_order_adj/models/sale_order.py
+++ b/sale_order_adj/models/sale_order.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-# Copyright 2018 Quartile Limited
+# Copyright 2018-2020 Quartile Limited
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl).
 
-from odoo import fields, models
+from odoo import api, fields, models, _
+from odoo.exceptions import UserError
 
 
 class SaleOrder(models.Model):
@@ -12,6 +13,18 @@ class SaleOrder(models.Model):
         related='project_project_id.user_id',
         string='Project Manager',
     )
+    gross_profit_margin_input = fields.Char(
+        string='Gross Profit Margin',
+        required=True,
+    )
     gross_profit_margin = fields.Float(
         string='Gross Profit Margin',
     )
+
+    @api.onchange('gross_profit_margin_input')
+    def _onchange_gross_profit_margin_input(self):
+        if self.gross_profit_margin_input:
+            try:
+                self.gross_profit_margin = float(self.gross_profit_margin_input)
+            except Exception:
+                raise UserError(_("The gross_profit_margin must be a number."))

--- a/sale_order_adj/views/sale_order_views.xml
+++ b/sale_order_adj/views/sale_order_views.xml
@@ -74,7 +74,8 @@
                ref="account_analytic_profit_loss_analysis.view_order_form"/>
         <field name="arch" type="xml">
             <xpath expr="//field[@name='parent_project_id']" position="after">
-                <field name="gross_profit_margin"/>
+                <field name="gross_profit_margin" class="oe_read_only"/>
+                <field name="gross_profit_margin_input" class="oe_edit_only"/>
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
Task#[1062](https://www.quartile.co/web?debug=#id=1062&action=771&model=project.task&view_type=form&menu_id=505)

- Add a new required `Char` field `gross_profit_margin_input` to sale.order (Since 0.0 will be assigned to `Float` field by default).
    - Edit Mode: `gross_profit_margin_input`
    - Read Mode: `gross_profit_margin`
- Set `gross_profit_margin_input` value to `gross_profit_margin` in onchange method.